### PR TITLE
Add prompt_template parameter for per-sample prompt customization. 

### DIFF
--- a/R/task.R
+++ b/R/task.R
@@ -67,6 +67,15 @@
 #' The value of `epochs` supplied to `$eval()` or `$score()` will take
 #' precedence over the value in `$new()`.
 #'
+#' @param prompt_template An optional prompt template for per-sample
+#' customization using `{{ column_name }}` syntax. When provided, values from
+#' metadata columns in the dataset are interpolated into the template, which
+#' is then prepended to each sample's `input`. For example,
+#' `"Always pick {{ shape }}."` with a `shape` column would prepend
+#' `"Always pick square.\n\n"` to the input for rows where `shape` is
+#' `"square"`. If `NULL` (the default), inputs are passed to the solver
+#' unchanged.
+#'
 #' @seealso [generate()] for the simplest possible solver, and
 #' [scorer_model] and [scorer_detect] for two built-in approaches to
 #' scoring.
@@ -138,6 +147,7 @@ Task <- R6::R6Class(
       scorer,
       metrics = NULL,
       epochs = NULL,
+      prompt_template = NULL,
       name = deparse(substitute(dataset)),
       dir = vitals_log_dir()
     ) {
@@ -150,9 +160,9 @@ Task <- R6::R6Class(
       check_dataset(dataset)
       check_log_dir(dir)
       check_function(solver)
-      # TODO: for non-built in scorers, what to do?
       check_metrics(metrics)
       check_number_whole(epochs, min = 1, allow_null = TRUE)
+      check_string(prompt_template, allow_null = TRUE)
 
       # dataset names can contain dashes or alphanumerics--transition
       # underscores and spaces to dashes (#92)
@@ -171,6 +181,7 @@ Task <- R6::R6Class(
 
       private$task_id <- substr(hash(c(name, solver_name, scorer_name)), 1, 22)
       private$epochs <- epochs
+      private$prompt_template <- prompt_template
 
       private$samples <- set_id_column(dataset)
     },
@@ -272,7 +283,9 @@ Task <- R6::R6Class(
       private$samples$solver_chat <- NA
 
       private$track_token_usage("solver_token_usage")
-      private$solutions <- private$solver(self$get_samples()$input, ...)
+      samples <- self$get_samples()
+      prompts <- interpolate_prompts(samples, private$prompt_template)
+      private$solutions <- private$solver(prompts, ...)
 
       # TODO: it might be nice to just run one of the inputs async and check for
       # this earlier on so that a full eval's worth of results isn't thrown
@@ -842,7 +855,8 @@ Task <- R6::R6Class(
     task_id = NULL,
     run_id = NULL,
 
-    epochs = NULL
+    epochs = NULL,
+    prompt_template = NULL
   )
 )
 
@@ -1013,4 +1027,16 @@ numeric_price <- function(price) {
   result <- as.numeric(gsub("\\$", "", price))
   result[is.na(result)] <- 0
   result
+}
+
+interpolate_prompts <- function(samples, template) {
+  if (is.null(template)) {
+    return(samples$input)
+  }
+
+  purrr::map_chr(seq_len(nrow(samples)), function(i) {
+    row_data <- as.list(samples[i, , drop = FALSE])
+    prefix <- ellmer::interpolate(template, !!!row_data)
+    paste0(prefix, "\n\n", samples$input[[i]])
+  })
 }

--- a/man/Task.Rd
+++ b/man/Task.Rd
@@ -108,6 +108,7 @@ calling this method and then \verb{$eval()} on the resulting object.
   scorer,
   metrics = NULL,
   epochs = NULL,
+  prompt_template = NULL,
   name = deparse(substitute(dataset)),
   dir = vitals_log_dir()
 )}\if{html}{\out{</div>}}
@@ -171,6 +172,15 @@ for examples.}
 multiple times to better quantify variation. Optional, defaults to \code{1L}.
 The value of \code{epochs} supplied to \verb{$eval()} or \verb{$score()} will take
 precedence over the value in \verb{$new()}.}
+
+\item{\code{prompt_template}}{An optional prompt template for per-sample
+customization using \code{{{ column_name }}} syntax. When provided, values from
+metadata columns in the dataset are interpolated into the template, which
+is then prepended to each sample's \code{input}. For example,
+\code{"Always pick {{ shape }}."} with a \code{shape} column would prepend
+\code{"Always pick square.\\n\\n"} to the input for rows where \code{shape} is
+\code{"square"}. If \code{NULL} (the default), inputs are passed to the solver
+unchanged.}
 
 \item{\code{name}}{A name for the evaluation task. Defaults to
 \code{deparse(substitute(dataset))}.}

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -1103,3 +1103,118 @@ test_that("$log() respects dir argument", {
   expect_equal(length(files_in_arg_dir), 1)
   expect_equal(length(files_in_env_dir), 0)
 })
+
+# prompt_template ---------------------------------------------------------
+test_that("prompt_template interpolates metadata into prompts", {
+  vcr::local_cassette("task-prompt-template")
+  key_get("OPENAI_API_KEY")
+  tmp_dir <- withr::local_tempdir()
+  withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  shapes_data <- tibble::tibble(
+    input = c("The shapes are square, circle and rhombus"),
+    target = c("square"),
+    shape_to_pick = c("square")
+  )
+
+  tsk <- Task$new(
+    dataset = shapes_data,
+    solver = generate(chat_openai(model = "gpt-4.1-nano")),
+    scorer = detect_match("any"),
+    prompt_template = "Always pick {{ shape_to_pick }}. Just return the shape name."
+  )
+
+  tsk$eval()
+  expect_valid_log(tsk$log())
+
+  expect_equal(nrow(tsk$get_samples()), 1)
+})
+
+test_that("prompt_template works with generate_structured", {
+  vcr::local_cassette("task-prompt-template-structured")
+  key_get("OPENAI_API_KEY")
+  tmp_dir <- withr::local_tempdir()
+  withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  type_shape <- type_object(
+    shape = type_string("The name of the shape that was picked")
+  )
+
+  shapes_data <- tibble::tibble(
+    input = c("The shapes are square, circle and rhombus"),
+    target = c("square"),
+    shape_to_pick = c("square")
+  )
+
+  tsk <- Task$new(
+    dataset = shapes_data,
+    solver = generate_structured(
+      solver_chat = chat_openai(model = "gpt-4.1-nano"),
+      type = type_shape
+    ),
+    scorer = detect_match("any"),
+    prompt_template = "Always pick {{ shape_to_pick }}."
+  )
+
+  tsk$eval()
+  expect_valid_log(tsk$log())
+
+  expect_equal(nrow(tsk$get_samples()), 1)
+  expect_true("solver_metadata" %in% names(tsk$get_samples()))
+})
+
+test_that("prompt_template=NULL preserves original behavior", {
+  vcr::local_cassette("task-prompt-template-null")
+  key_get("OPENAI_API_KEY")
+  tmp_dir <- withr::local_tempdir()
+  withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = generate(chat_openai(model = "gpt-4.1-nano")),
+    scorer = model_graded_qa(),
+    prompt_template = NULL
+  )
+
+  tsk$eval()
+  expect_valid_log(tsk$log())
+
+  expect_equal(nrow(tsk$get_samples()), 2)
+})
+
+test_that("interpolate_prompts works correctly", {
+  samples <- tibble::tibble(
+    input = c("Question 1", "Question 2"),
+    target = c("A", "B"),
+    context = c("Context A", "Context B")
+  )
+
+  result <- interpolate_prompts(samples, NULL)
+  expect_equal(result, c("Question 1", "Question 2"))
+
+  result <- interpolate_prompts(samples, "{{ context }}")
+  expect_equal(result, c("Context A\n\nQuestion 1", "Context B\n\nQuestion 2"))
+
+  result <- interpolate_prompts(samples, "Use {{ context }} to answer.")
+  expect_equal(
+    result,
+    c(
+      "Use Context A to answer.\n\nQuestion 1",
+      "Use Context B to answer.\n\nQuestion 2"
+    )
+  )
+})


### PR DESCRIPTION
Fixes #201.

## Solution                                                                  
                                                                               
Add a `prompt_template` argument to `Task$new()` that:                          
1. Uses `{{ column_name }}` syntax (via `ellmer::interpolate()`) to reference metadata columns                                                               
2. Automatically prepends the interpolated template to each sample's `input`    
3. Works with both `generate()` and `generate_structured()` solvers             
                                                                               
## Examples                                                                     
                                                                               
### With `generate()`                                                           
                                                                               
```r                                                                         
library(vitals)                                                                 
library(ellmer)                                                                 
library(tibble)                                                                 
                                                                               
shapes_data <- tibble(                                                          
 input = c(                                                                    
   "The shapes are square, circle and rhombus",                                
   "The shapes are square, circle and rhombus",                                
   "The shapes are square, circle and rhombus"                                 
 ),                                                                            
 target = c("square", "circle", "rhombus"),                                    
 shape_to_pick = c("square", "circle", "rhombus")                              
)                                                                               
                                                                               
tsk <- Task$new(                                                                
 dataset = shapes_data,                                                        
 solver = generate(chat_anthropic(model = "claude-sonnet-4-5")),               
 scorer = detect_match("any"),                                                 
 prompt_template = "Always pick {{ shape_to_pick }}. Just return the single chosen shape as 1 word.",                                                       
 dir = tempdir()                                                               
)                                                                               
                                                                               
tsk$eval()                                                                      
```

Desired result:

```
tsk$get_samples()$result
[1] "square"  "circle"  "rhombus"
```
                                                                        
                                                                               
### With `generate_structured()`                                                
                                                                               
```r                                                                         
type_shape <- type_object(                                                      
 shape = type_string("The name of the shape that was picked")                  
)                                                                               
                                                                               
shapes_data <- tibble(                                                          
 input = c(                                                                    
   "The shapes are square, circle and rhombus",                                
   "The shapes are square, circle and rhombus",                                
   "The shapes are square, circle and rhombus"                                 
 ),                                                                            
 target = c("square", "circle", "rhombus"),                                    
 shape_to_pick = c("square", "circle", "rhombus")                              
)                                                                               
                                                                               
tsk_str <- Task$new(                                                            
 dataset = shapes_data,                                                        
 solver = generate_structured(                                                 
   solver_chat = chat_anthropic(model = "claude-sonnet-4-5"),                  
   type = type_shape                                                           
 ),                                                                            
 scorer = detect_match("any"),                                                 
 prompt_template = "Always pick {{ shape_to_pick }}. Just return the single chosen shape as 1 word.",                                                       
 dir = tempdir()                                                               
)                                                                               
                                                                               
tsk_str$eval()                                                                  
```         

Desired result:
```
tsk_str$get_samples()$result
[1] "[{\"shape\":\"square\"}]"  "[{\"shape\":\"circle\"}]"  "[{\"shape\":\"rhombus\"}]"
```                                                             
                                                                               
## Implementation Notes                                                         
                                                                               
- The template is interpolated at the `Task` level in `$solve()`, keeping solvers simple and unchanged                                                    
- Uses `ellmer::interpolate()` which uses `{{ }}` syntax (avoids conflicts with JSON/R code)                                                               
- The interpolated template is prepended to the input with `\n\n` separator     
- When `prompt_template = NULL` (default), behavior is unchanged