### PR TITLE
patch viewer get_log() to key in-flight requests by file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ inst/doc
 **/.quarto/
 inst/inspect_ai/
 inst/ellmer
+plans/

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * The log viewer will now appropriately display tool calls called in parallel.
 
+* Fixed an issue where the log viewer could display one log's metadata (task
+  name, model, score) in place of another's, both in the log listing and when
+  clicking into a log (#208).
+
 # vitals 0.3.0
 
 ## New features

--- a/inst/README.md
+++ b/inst/README.md
@@ -20,6 +20,17 @@ inspect eval test/inspect/tools.py  --model anthropic/claude-sonnet-4-5 --log-fo
 
 `/dist` is a bundled version of the Inspect viewer. (See [here](https://github.com/UKGovernmentBEIS/inspect_ai/blob/88d1cd98041a245c1d0cca4536d60e3244630b78/src/inspect_ai/_view/www/README.md) for more information.)
 
+`dist/assets/index.js` carries one local patch on top of the upstream build
+(#208): in `clientApi()`'s `get_log()`, the single shared `pending_log_promise`
+is replaced with a per-file `pending_log_promises` Map. Upstream, any caller
+requesting a log while another log's request is in flight receives that other
+log's contents, which poisons the viewer's IndexedDB cache and swaps metadata
+between logs in the listing. The bug only affects `.json` logs (Inspect itself
+defaults to `.eval`), so it is still present upstream as of `inspect_ai`
+0.3.179+ (viewer source: `meridianlabs-ai/ts-mono`, `client-api.ts`). When
+porting a new viewer version, check whether upstream has fixed this; if not,
+re-apply the patch by searching the new bundle for `pending_log_promise`.
+
 **regenerate-example-objects.R**
 
 The package defines a function `regenerate_example_objects()` in the source that sources the script `inst/regenerate-example-objects.R`.

--- a/inst/dist/assets/index.js
+++ b/inst/dist/assets/index.js
@@ -109095,23 +109095,25 @@ self.onmessage = function (e) {
       };
       const get_log = async (log_file2, cached = false) => {
         if (!cached || log_file2 !== current_path || !current_log) {
-          if (pending_log_promise) {
-            return pending_log_promise;
+          const pending = pending_log_promises.get(log_file2);
+          if (pending) {
+            return pending;
           }
-          pending_log_promise = api2.get_log_contents(log_file2, 100).then((log2) => {
+          const promise = api2.get_log_contents(log_file2, 100).then((log2) => {
             current_log = log2;
             current_path = log_file2;
-            pending_log_promise = null;
+            pending_log_promises.delete(log_file2);
             return log2;
           }).catch((err2) => {
-            pending_log_promise = null;
+            pending_log_promises.delete(log_file2);
             throw err2;
           });
-          return pending_log_promise;
+          pending_log_promises.set(log_file2, promise);
+          return promise;
         }
         return current_log;
       };
-      let pending_log_promise = null;
+      const pending_log_promises = /* @__PURE__ */ new Map();
       const get_log_details = async (log_file2) => {
         if (isEvalFile(log_file2)) {
           const remoteLogFile = await remoteEvalFile(log_file2);


### PR DESCRIPTION
Closes #208.

The vendored viewer shared a single pending_log_promise across all get_log() callers, so any log requested while another's fetch was in flight received that other log's contents. The home page's detail prefetch queue issues these requests in a concurrent burst, which deterministically cached the first log's contents under every other log's file path in IndexedDB; clicking a log then rebuilt its listing preview from the poisoned cache, showing another log's metadata. The race is still present upstream as of inspect_ai 0.3.179+, so the bundle is patched locally and the patch documented in inst/README.md for future viewer ports.